### PR TITLE
FIX: install `uv` through `pip` on Read the Docs

### DIFF
--- a/.constraints/py3.10.txt
+++ b/.constraints/py3.10.txt
@@ -72,7 +72,7 @@ jupyter-lsp==2.2.5
 jupyter-server==2.14.0
 jupyter-server-mathjax==0.2.6
 jupyter-server-terminals==0.5.3
-jupyterlab==4.2.0
+jupyterlab==4.2.1
 jupyterlab-code-formatter==2.2.1
 jupyterlab-git==0.50.1
 jupyterlab-lsp==5.1.0

--- a/.constraints/py3.10.txt
+++ b/.constraints/py3.10.txt
@@ -64,7 +64,7 @@ jsonschema==4.22.0
 jsonschema-specifications==2023.12.1
 jupyter==1.0.0
 jupyter-cache==1.0.0
-jupyter-client==8.6.1
+jupyter-client==8.6.2
 jupyter-console==6.6.3
 jupyter-core==5.7.2
 jupyter-events==0.10.0
@@ -78,7 +78,7 @@ jupyterlab-git==0.50.1
 jupyterlab-lsp==5.1.0
 jupyterlab-myst==2.4.2
 jupyterlab-pygments==0.3.0
-jupyterlab-server==2.27.1
+jupyterlab-server==2.27.2
 jupyterlab-widgets==3.0.10
 kiwisolver==1.4.5
 latexcodec==3.0.0
@@ -143,7 +143,7 @@ rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rope==1.13.0
 rpds-py==0.18.1
-ruff==0.4.4
+ruff==0.4.5
 send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
@@ -157,7 +157,7 @@ sphinx-book-theme==1.1.2
 sphinx-codeautolink==0.15.1
 sphinx-comments==0.0.3
 sphinx-copybutton==0.5.2
-sphinx-design==0.5.0
+sphinx-design==0.6.0
 sphinx-hep-pdgref==0.2.0
 sphinx-pybtex-etal-style==0.0.2
 sphinx-remove-toctrees==1.0.0.post1

--- a/.constraints/py3.11.txt
+++ b/.constraints/py3.11.txt
@@ -63,7 +63,7 @@ jsonschema==4.22.0
 jsonschema-specifications==2023.12.1
 jupyter==1.0.0
 jupyter-cache==1.0.0
-jupyter-client==8.6.1
+jupyter-client==8.6.2
 jupyter-console==6.6.3
 jupyter-core==5.7.2
 jupyter-events==0.10.0
@@ -77,7 +77,7 @@ jupyterlab-git==0.50.1
 jupyterlab-lsp==5.1.0
 jupyterlab-myst==2.4.2
 jupyterlab-pygments==0.3.0
-jupyterlab-server==2.27.1
+jupyterlab-server==2.27.2
 jupyterlab-widgets==3.0.10
 kiwisolver==1.4.5
 latexcodec==3.0.0
@@ -142,7 +142,7 @@ rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rope==1.13.0
 rpds-py==0.18.1
-ruff==0.4.4
+ruff==0.4.5
 send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
@@ -156,7 +156,7 @@ sphinx-book-theme==1.1.2
 sphinx-codeautolink==0.15.1
 sphinx-comments==0.0.3
 sphinx-copybutton==0.5.2
-sphinx-design==0.5.0
+sphinx-design==0.6.0
 sphinx-hep-pdgref==0.2.0
 sphinx-pybtex-etal-style==0.0.2
 sphinx-remove-toctrees==1.0.0.post1

--- a/.constraints/py3.11.txt
+++ b/.constraints/py3.11.txt
@@ -71,7 +71,7 @@ jupyter-lsp==2.2.5
 jupyter-server==2.14.0
 jupyter-server-mathjax==0.2.6
 jupyter-server-terminals==0.5.3
-jupyterlab==4.2.0
+jupyterlab==4.2.1
 jupyterlab-code-formatter==2.2.1
 jupyterlab-git==0.50.1
 jupyterlab-lsp==5.1.0

--- a/.constraints/py3.12.txt
+++ b/.constraints/py3.12.txt
@@ -63,7 +63,7 @@ jsonschema==4.22.0
 jsonschema-specifications==2023.12.1
 jupyter==1.0.0
 jupyter-cache==1.0.0
-jupyter-client==8.6.1
+jupyter-client==8.6.2
 jupyter-console==6.6.3
 jupyter-core==5.7.2
 jupyter-events==0.10.0
@@ -77,7 +77,7 @@ jupyterlab-git==0.50.1
 jupyterlab-lsp==5.1.0
 jupyterlab-myst==2.4.2
 jupyterlab-pygments==0.3.0
-jupyterlab-server==2.27.1
+jupyterlab-server==2.27.2
 jupyterlab-widgets==3.0.10
 kiwisolver==1.4.5
 latexcodec==3.0.0
@@ -142,7 +142,7 @@ rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rope==1.13.0
 rpds-py==0.18.1
-ruff==0.4.4
+ruff==0.4.5
 send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
@@ -156,7 +156,7 @@ sphinx-book-theme==1.1.2
 sphinx-codeautolink==0.15.1
 sphinx-comments==0.0.3
 sphinx-copybutton==0.5.2
-sphinx-design==0.5.0
+sphinx-design==0.6.0
 sphinx-hep-pdgref==0.2.0
 sphinx-pybtex-etal-style==0.0.2
 sphinx-remove-toctrees==1.0.0.post1

--- a/.constraints/py3.12.txt
+++ b/.constraints/py3.12.txt
@@ -71,7 +71,7 @@ jupyter-lsp==2.2.5
 jupyter-server==2.14.0
 jupyter-server-mathjax==0.2.6
 jupyter-server-terminals==0.5.3
-jupyterlab==4.2.0
+jupyterlab==4.2.1
 jupyterlab-code-formatter==2.2.1
 jupyterlab-git==0.50.1
 jupyterlab-lsp==5.1.0

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -109,7 +109,6 @@ numpy==1.21.6
 packaging==24.0
 pandocfilters==1.5.1
 parso==0.8.4
-pathlib2==2.3.7.post1
 pathspec==0.11.2
 pexpect==4.9.0
 pickleshare==0.7.5

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -66,7 +66,7 @@ jsonschema==4.22.0
 jsonschema-specifications==2023.12.1
 jupyter==1.0.0
 jupyter-cache==0.6.1
-jupyter-client==8.6.1
+jupyter-client==8.6.2
 jupyter-console==6.6.3
 jupyter-core==5.7.2
 jupyter-events==0.10.0
@@ -80,7 +80,7 @@ jupyterlab-git==0.50.1
 jupyterlab-lsp==5.1.0
 jupyterlab-myst==2.4.2
 jupyterlab-pygments==0.3.0
-jupyterlab-server==2.27.1
+jupyterlab-server==2.27.2
 jupyterlab-widgets==3.0.10
 kiwisolver==1.4.5
 latexcodec==3.0.0
@@ -111,7 +111,6 @@ overrides==7.7.0
 packaging==24.0
 pandocfilters==1.5.1
 parso==0.8.4
-pathlib2==2.3.7.post1
 pathspec==0.12.1
 pexpect==4.9.0
 pickleshare==0.7.5
@@ -150,7 +149,7 @@ rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rope==1.13.0
 rpds-py==0.18.1
-ruff==0.4.4
+ruff==0.4.5
 send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -74,7 +74,7 @@ jupyter-lsp==2.2.5
 jupyter-server==2.14.0
 jupyter-server-mathjax==0.2.6
 jupyter-server-terminals==0.5.3
-jupyterlab==4.2.0
+jupyterlab==4.2.1
 jupyterlab-code-formatter==2.2.1
 jupyterlab-git==0.50.1
 jupyterlab-lsp==5.1.0

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -65,7 +65,7 @@ jsonschema==4.22.0
 jsonschema-specifications==2023.12.1
 jupyter==1.0.0
 jupyter-cache==1.0.0
-jupyter-client==8.6.1
+jupyter-client==8.6.2
 jupyter-console==6.6.3
 jupyter-core==5.7.2
 jupyter-events==0.10.0
@@ -79,7 +79,7 @@ jupyterlab-git==0.50.1
 jupyterlab-lsp==5.1.0
 jupyterlab-myst==2.4.2
 jupyterlab-pygments==0.3.0
-jupyterlab-server==2.27.1
+jupyterlab-server==2.27.2
 jupyterlab-widgets==3.0.10
 kiwisolver==1.4.5
 latexcodec==3.0.0
@@ -144,7 +144,7 @@ rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rope==1.13.0
 rpds-py==0.18.1
-ruff==0.4.4
+ruff==0.4.5
 send2trash==1.8.3
 six==1.16.0
 smmap==5.0.1
@@ -158,7 +158,7 @@ sphinx-book-theme==1.1.2
 sphinx-codeautolink==0.15.1
 sphinx-comments==0.0.3
 sphinx-copybutton==0.5.2
-sphinx-design==0.5.0
+sphinx-design==0.6.0
 sphinx-hep-pdgref==0.2.0
 sphinx-pybtex-etal-style==0.0.2
 sphinx-remove-toctrees==1.0.0.post1

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -73,7 +73,7 @@ jupyter-lsp==2.2.5
 jupyter-server==2.14.0
 jupyter-server-mathjax==0.2.6
 jupyter-server-terminals==0.5.3
-jupyterlab==4.2.0
+jupyterlab==4.2.1
 jupyterlab-code-formatter==2.2.1
 jupyterlab-git==0.50.1
 jupyterlab-lsp==5.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
             metadata.vscode
 
   - repo: https://github.com/ComPWA/policy
-    rev: 0.3.8
+    rev: 0.3.9
     hooks:
       - id: check-dev-files
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
       - id: fix-nbformat-version
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4
+    rev: v0.4.5
     hooks:
       - id: ruff
         args: [--fix]
@@ -159,6 +159,6 @@ repos:
           - jupyter
 
   - repo: https://github.com/ComPWA/mirrors-pyright
-    rev: v1.1.363
+    rev: v1.1.364
     hooks:
       - id: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,15 @@ repos:
   - repo: https://github.com/ComPWA/policy
     rev: 0.3.8
     hooks:
+      - id: check-dev-files
+        args:
+          - --doc-apt-packages=graphviz
+          - --dev-python-version=3.10
+          - --github-pages
+          - --no-prettierrc
+          - --pin-requirements=bimonthly
+          - --repo-name=compwa.github.io
+          - --repo-title=ComPWA Organization
       - id: colab-toc-visible
       - id: fix-nbformat-version
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,10 @@ repos:
           - |
             cell.attachments
             cell.metadata.code_folding
+            cell.metadata.editable
             cell.metadata.id
             cell.metadata.pycharm
+            cell.metadata.slideshow
             cell.metadata.user_expressions
             metadata.celltoolbar
             metadata.colab.name

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,15 +44,6 @@ repos:
   - repo: https://github.com/ComPWA/policy
     rev: 0.3.8
     hooks:
-      - id: check-dev-files
-        args:
-          - --doc-apt-packages=graphviz
-          - --dev-python-version=3.10
-          - --github-pages
-          - --no-prettierrc
-          - --pin-requirements=bimonthly
-          - --repo-name=compwa.github.io
-          - --repo-title=ComPWA Organization
       - id: colab-toc-visible
       - id: fix-nbformat-version
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,5 @@ build:
     pre_install:
       - ./docs/install-julia-on-rtd.sh
     post_install:
-      - curl -LsSf https://astral.sh/uv/install.sh | sh
-      - |-
-        /home/docs/.cargo/bin/uv pip install --system -c .constraints/py3.10.txt -e .[doc]
+      - python -m pip install 'uv>=0.2.0'
+      - python -m uv pip install -c .constraints/py3.10.txt -e .[doc]

--- a/docs/report/003.ipynb
+++ b/docs/report/003.ipynb
@@ -39,10 +39,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "remove-cell"
     ]
@@ -55,10 +51,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -69,15 +61,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
     "mystnb": {
      "code_prompt_show": "Import Python libraries"
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-cell"
@@ -124,7 +112,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -147,10 +134,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -160,10 +143,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -189,12 +168,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -211,12 +186,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input",
@@ -272,10 +243,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -286,10 +253,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "hide-input"
     ]
@@ -305,10 +268,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "hide-input"
     ]
@@ -321,12 +280,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -342,10 +297,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -358,10 +309,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -372,15 +319,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
     "mystnb": {
      "code_prompt_show": "Define sliders and plot range"
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-cell"
@@ -432,12 +375,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "remove-output",
@@ -531,12 +470,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "remove-input",
@@ -555,10 +490,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -570,10 +501,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -583,10 +510,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -609,10 +532,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -623,12 +542,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input",
@@ -665,10 +580,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -679,12 +590,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -698,10 +605,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -711,12 +614,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "s_thr = (m1 + m2) ** 2\n",
@@ -729,10 +627,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -743,10 +637,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -761,10 +651,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -776,10 +662,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -790,10 +672,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -806,10 +684,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -819,12 +693,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "s_thr_val = float(s_thr.subs({m1: m1_val, m2: m2_val}))\n",
@@ -849,10 +718,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -863,10 +728,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -881,12 +742,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "remove-output",
@@ -918,12 +775,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "remove-input"
@@ -941,10 +794,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -962,12 +811,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "mystnb": {
      "code_prompt_show": "Symbolic integral definition"
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-cell"
@@ -1011,15 +856,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
     "mystnb": {
      "code_prompt_show": "Definition of the symbolic dispersion integral"
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -1061,10 +902,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -1081,10 +918,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -1111,12 +944,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -1134,10 +963,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -1149,10 +974,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -1165,10 +986,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -1179,12 +996,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input",
@@ -1224,12 +1037,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "remove-input"
@@ -1264,7 +1073,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/report/004.ipynb
+++ b/docs/report/004.ipynb
@@ -94,7 +94,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -573,7 +572,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/report/005.ipynb
+++ b/docs/report/005.ipynb
@@ -103,7 +103,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -1048,7 +1047,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/report/006.ipynb
+++ b/docs/report/006.ipynb
@@ -83,7 +83,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -564,7 +563,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/report/009.ipynb
+++ b/docs/report/009.ipynb
@@ -159,7 +159,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -1026,7 +1025,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/report/010.ipynb
+++ b/docs/report/010.ipynb
@@ -101,7 +101,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -764,7 +763,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/report/016.ipynb
+++ b/docs/report/016.ipynb
@@ -11,10 +11,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "sympy"
     ]
@@ -34,10 +30,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -48,10 +40,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "remove-cell"
     ]
@@ -65,15 +53,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
     "mystnb": {
      "code_prompt_show": "Import Python libraries"
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -97,10 +81,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -110,10 +90,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -124,10 +100,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -138,10 +110,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "raises-exception"
     ]
@@ -158,10 +126,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -172,10 +136,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -201,10 +161,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -218,10 +174,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -232,10 +184,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -246,10 +194,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -260,10 +204,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -274,10 +214,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -294,10 +230,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -307,10 +239,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -322,10 +250,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -351,10 +275,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -373,10 +293,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -386,10 +302,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -400,10 +312,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "raises-exception"
     ]
@@ -425,10 +333,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -444,10 +348,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -487,10 +387,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -501,12 +397,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -537,10 +429,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -553,10 +441,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -567,10 +451,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -583,12 +463,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -607,10 +483,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -630,12 +502,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -657,10 +525,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -689,7 +553,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/report/017.ipynb
+++ b/docs/report/017.ipynb
@@ -96,7 +96,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -752,7 +751,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/report/021.ipynb
+++ b/docs/report/021.ipynb
@@ -166,7 +166,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -2506,7 +2505,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/report/024.ipynb
+++ b/docs/report/024.ipynb
@@ -11,10 +11,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "documentation"
     ]
@@ -35,10 +31,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -49,10 +41,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "remove-cell"
     ]
@@ -66,15 +54,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
     "mystnb": {
      "code_prompt_show": "Import Python libraries"
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "scroll-input",
@@ -104,10 +88,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -117,10 +97,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -131,10 +107,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -147,10 +119,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -161,10 +129,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -176,12 +140,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -202,10 +162,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -216,10 +172,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -231,10 +183,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -248,12 +196,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input",
@@ -306,10 +250,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -319,10 +259,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -333,10 +269,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -374,10 +306,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -388,10 +316,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -405,10 +329,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -419,10 +339,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -438,10 +354,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -452,10 +364,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -466,10 +374,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -482,12 +386,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": []
    },
@@ -503,10 +403,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -517,10 +413,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -533,10 +425,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -547,12 +435,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -573,10 +457,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -587,12 +467,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -607,10 +483,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -620,10 +492,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -634,10 +502,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -652,12 +516,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "remove-input"
@@ -677,10 +537,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -690,10 +546,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -704,10 +556,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -721,12 +569,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -752,10 +596,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -766,10 +606,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "raises-exception"
     ]
@@ -782,10 +618,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -796,10 +628,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -817,10 +645,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -834,12 +658,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "remove-input"
@@ -853,10 +673,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -867,12 +683,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": []
    },
@@ -887,10 +699,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -901,10 +709,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -916,10 +720,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -929,10 +729,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -943,10 +739,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -958,12 +750,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "full-width",
@@ -979,12 +767,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -998,10 +782,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -1012,10 +792,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -1029,10 +805,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -1042,10 +814,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -1056,10 +824,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -1074,10 +838,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -1088,10 +848,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "remove-input"
     ]
@@ -1104,10 +860,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -1118,10 +870,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -1135,10 +883,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -1167,7 +911,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/report/025.ipynb
+++ b/docs/report/025.ipynb
@@ -11,10 +11,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -32,10 +28,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -46,10 +38,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "remove-cell"
     ]
@@ -63,12 +51,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-cell"
@@ -98,7 +82,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -121,10 +104,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -138,10 +117,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -152,12 +127,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input",
@@ -205,10 +176,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -221,12 +188,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input",
@@ -305,10 +268,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -319,12 +278,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -372,12 +327,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input",
@@ -474,12 +425,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "remove-input",
@@ -498,10 +445,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -530,7 +473,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/report/026.ipynb
+++ b/docs/report/026.ipynb
@@ -11,7 +11,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -29,7 +28,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -39,7 +37,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -50,7 +47,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": [
      "remove-cell"
     ]
@@ -65,7 +61,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -98,7 +93,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -110,7 +104,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -197,7 +190,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -216,7 +208,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "tags": []
    },
    "outputs": [],
@@ -232,7 +223,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "outputs": [],
@@ -245,7 +235,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "outputs": [],
@@ -259,7 +248,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "tags": [
      "hide-input"
     ]
@@ -289,7 +277,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "outputs": [],
@@ -348,7 +335,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "outputs": [],
@@ -376,7 +362,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "outputs": [],
@@ -387,7 +372,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -398,7 +382,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "mystnb": {
      "code_prompt_show": "Define numerical functions"
     },
@@ -418,7 +401,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "mystnb": {
      "code_prompt_show": "Define meshgrid and parameter values"
     },
@@ -456,7 +438,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -496,7 +477,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -515,7 +495,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -571,7 +550,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jp-MarkdownHeadingCollapsed": true,
     "jupyter": {
      "source_hidden": true
@@ -639,7 +617,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -649,7 +626,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -679,7 +655,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   },
   "orphan": true
  },

--- a/docs/report/027.ipynb
+++ b/docs/report/027.ipynb
@@ -11,7 +11,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -29,7 +28,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -40,7 +38,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": [
      "remove-cell"
     ]
@@ -55,7 +52,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -95,7 +91,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -120,7 +115,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -143,7 +137,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -155,7 +148,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -188,7 +180,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -273,7 +264,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -283,7 +273,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -295,7 +284,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -322,7 +310,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "outputs": [],
@@ -335,7 +322,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "outputs": [],
@@ -347,7 +333,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -359,7 +344,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -390,7 +374,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -419,7 +402,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "outputs": [],
@@ -431,7 +413,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -441,7 +422,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -466,7 +446,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -497,7 +476,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": [
      "full-width"
     ]
@@ -512,7 +490,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": [
      "full-width"
     ]
@@ -527,7 +504,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": [
      "full-width"
     ]
@@ -542,7 +518,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "outputs": [],
@@ -582,7 +557,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "outputs": [],
@@ -594,7 +568,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "outputs": [],
@@ -623,7 +596,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -722,7 +694,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -732,7 +703,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "tags": []
    },
    "source": [
@@ -744,7 +714,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -813,7 +782,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
     "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
@@ -826,7 +794,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -885,7 +852,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "jupyter": {
      "source_hidden": true
     },
@@ -1030,7 +996,6 @@
    "execution_count": null,
    "metadata": {
     "cellView": "form",
-    "editable": true,
     "tags": [
      "hide-input",
      "scroll-input"

--- a/docs/report/028.ipynb
+++ b/docs/report/028.ipynb
@@ -11,10 +11,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "PDG"
     ]
@@ -34,10 +30,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -48,10 +40,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "remove-cell"
     ]
@@ -65,10 +53,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "remove-cell"
     ]
@@ -82,10 +66,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -98,10 +78,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -112,10 +88,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -126,10 +98,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -139,12 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "jpsi_decay = PDG.get(\"M070.313/2023\")\n",
@@ -155,10 +118,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -169,10 +128,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -183,10 +138,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -201,10 +152,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -226,12 +173,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -266,10 +209,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -280,10 +219,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -300,10 +235,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -319,10 +250,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -333,12 +260,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -359,10 +282,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -375,10 +294,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -389,10 +304,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -403,12 +314,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"

--- a/docs/report/029.ipynb
+++ b/docs/report/029.ipynb
@@ -3,10 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -17,10 +13,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "PDG"
     ]
@@ -38,10 +30,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -52,10 +40,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "remove-cell"
     ]
@@ -69,12 +53,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -103,10 +83,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -122,10 +98,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -137,10 +109,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -150,10 +118,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -170,10 +134,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -187,10 +147,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -219,10 +175,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -232,10 +184,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -284,10 +232,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -297,10 +241,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -313,10 +253,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "scroll-input"
     ]
@@ -365,12 +301,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -393,12 +325,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -414,12 +342,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -434,10 +358,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -447,10 +367,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -461,10 +377,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -491,10 +403,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -509,12 +417,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -530,10 +434,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -544,12 +444,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -564,10 +460,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -577,10 +469,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -591,12 +479,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -612,10 +496,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -626,10 +506,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -641,10 +517,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "full-width"
     ]
@@ -657,10 +529,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -671,10 +539,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -686,10 +550,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "full-width"
     ]

--- a/docs/symbolics.ipynb
+++ b/docs/symbolics.ipynb
@@ -26,10 +26,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "remove-cell"
     ]
@@ -94,10 +90,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -110,10 +102,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -125,10 +113,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -138,10 +122,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -152,10 +132,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -169,10 +145,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -182,10 +154,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -195,10 +163,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -209,10 +173,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -226,10 +186,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -240,10 +196,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -350,10 +302,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -416,10 +364,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -431,10 +375,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "hide-input"
     ]
@@ -469,10 +409,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -492,12 +428,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "hide-input"
@@ -519,10 +451,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -533,10 +461,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "hide-input"
     ]
@@ -552,10 +476,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -566,10 +486,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": [
      "scroll-output",
      "scroll-input",
@@ -629,10 +545,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -644,12 +556,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "remove-input"
@@ -670,10 +578,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "outputs": [],
@@ -685,12 +589,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "editable": true,
     "jupyter": {
      "source_hidden": true
-    },
-    "slideshow": {
-     "slide_type": ""
     },
     "tags": [
      "remove-input"
@@ -706,10 +606,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -721,10 +617,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -736,10 +628,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -753,10 +641,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -792,10 +676,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -805,10 +685,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -824,10 +700,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
     "tags": []
    },
    "source": [
@@ -867,7 +739,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- [x] 2b7cf61 Upgrade to Ruff v0.4.4 (`ruff server`, see [blog](https://astral.sh/blog/ruff-v0.4.5))
- [x] Migrate to `uv` v0.2 on RTD, see e.g. [this log](https://readthedocs.org/projects/compwa/builds/24467150/) and https://github.com/ComPWA/policy/pull/347