### PR TITLE
DOC: write `tox list` instead of `tox -av`

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -442,7 +442,7 @@ More specialized {command}`tox` job are defined in the
 they do, by running:
 
 ```shell
-tox -av
+tox list
 ```
 
 ### GitHub Actions


### PR DESCRIPTION
You can use
```shell
tox list
```
instead of
```shell
tox -e av
```